### PR TITLE
fix/drag-file-area-too-big

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -71,6 +71,49 @@ h1 {
     background-color: rgba(26, 115, 232, 0.1);
 }
 
+.upload-paste-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+    flex-wrap: wrap;
+}
+
+.upload-paste-row p {
+    margin: 0;
+    flex-grow: 1;
+    text-align: center;
+    color: var(--text-light);
+    font-size: 0.95em;
+}
+
+.text-btn {
+    background-color: transparent;
+    color: var(--primary-color);
+    border: 1px solid var(--border-light);
+    padding: 4px 12px;
+    border-radius: 14px;
+    cursor: pointer;
+    font-weight: 500;
+    transition: all 0.2s;
+    font-size: 0.85em;
+    white-space: nowrap;
+}
+
+.text-btn:hover {
+    background-color: rgba(26, 115, 232, 0.1);
+    border-color: var(--primary-color);
+}
+
+.text-btn:focus {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+}
+
+.text-btn:active {
+    background-color: rgba(26, 115, 232, 0.2);
+}
+
 textarea {
     width: 100%;
     min-height: 150px;
@@ -301,6 +344,21 @@ button:disabled {
 @media (prefers-color-scheme: dark) {
     .segment-title-bar:hover {
         background-color: rgba(255, 255, 255, 0.08);
+    }
+    .text-btn {
+        color: #8ab4f8; /* 暗色模式下更亮的蓝色 */
+        border-color: var(--border-light);
+    }
+    .text-btn:hover {
+        background-color: rgba(138, 180, 248, 0.1);
+        border-color: #8ab4f8;
+    }
+    .text-btn:focus {
+        outline: 2px solid #8ab4f8;
+        outline-offset: 2px;
+    }
+    .text-btn:active {
+        background-color: rgba(138, 180, 248, 0.2);
     }
 }
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -20,7 +20,9 @@ const els = {
     progressContainer: document.getElementById('progress-container'),
     statusMsg: document.getElementById('status-message'),
     apiStatus: document.getElementById('api-status'),
-    failedStatus: document.getElementById('failed-status')
+    failedStatus: document.getElementById('failed-status'),
+    uploadBtn: document.getElementById('upload-btn'),
+    pasteBtn: document.getElementById('paste-btn')
 };
 
 // 运行状态
@@ -64,9 +66,11 @@ function bindEventListeners() {
     els.inputArea.addEventListener('drop', handleDrop);
     els.inputArea.addEventListener('dragover', handleDragOver);
     els.inputArea.addEventListener('dragleave', handleDragLeave);
-    els.inputArea.addEventListener('click', handleInputAreaClick);
+    // els.inputArea.addEventListener('click', handleInputAreaClick); // 移除整个区域点击上传功能
     els.fileInput.addEventListener('change', handleFileInputChange);
     els.textInput.addEventListener('input', handleTextInput);
+    els.uploadBtn.addEventListener('click', handleUploadClick);
+    els.pasteBtn.addEventListener('click', handlePasteClick);
 }
 
 
@@ -694,12 +698,27 @@ function handleDragLeave() {
     els.inputArea.classList.remove('drag-over'); 
 }
 
-function handleInputAreaClick(e) { 
-    if(e.target === els.inputArea) els.fileInput.click(); 
+// function handleInputAreaClick(e) {
+//     if(e.target === els.inputArea) els.fileInput.click();
+// }
+
+function handleFileInputChange(e) {
+    if(e.target.files[0]) handleFile(e.target.files[0]);
 }
 
-function handleFileInputChange(e) { 
-    if(e.target.files[0]) handleFile(e.target.files[0]); 
+function handleUploadClick() {
+    els.fileInput.click();
+}
+
+async function handlePasteClick() {
+    try {
+        const text = await navigator.clipboard.readText();
+        els.textInput.value = text;
+        handleTextInput();
+    } catch (err) {
+        console.error('粘贴失败:', err);
+        alert('无法访问剪贴板，请确保已授予权限或手动粘贴');
+    }
 }
 
 // -------------------------------------

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,11 @@
         <h1>文言文分析工具</h1>
 
         <div id="input-area">
-            <p>将文件拖放到此处，或直接在下方粘贴文本</p>
+            <div class="upload-paste-row">
+                <button id="upload-btn" class="text-btn">上传</button>
+                <p>将文件拖放到此处，或直接在下方粘贴文本</p>
+                <button id="paste-btn" class="text-btn">粘贴</button>
+            </div>
             <input type="file" id="file-input" accept=".txt" style="display: none;">
             <textarea id="text-input" placeholder="请粘贴您的文言文材料..."></textarea>
 


### PR DESCRIPTION
fixes #4 
1. Removed the area click upload function – the original feature of popping up a file selection window upon clicking the area has been removed.
2. Added upload/paste buttons – added "Upload" and "Paste" buttons (both two characters) on the left and right sides of "Drag and drop files here, or paste text below."
3. Subtle and coordinated styling – buttons feature a transparent background, light-colored borders, and text in the main color tone, maintaining consistency with the overall interface style without drawing attention.
4. Functional adjustments:
   - Upload button: Click to select .txt files
   - Paste button: Read text from clipboard and populate the input field
   - Drag-and-drop function: Maintain the original drag-and-drop upload functionality unchanged